### PR TITLE
ignore non-code assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+*.wav
+*.mp3
+config.ini
+__pycache__
+*.csv
+*.json
+*.txt
+.vscode
+synthesis/*


### PR DESCRIPTION
Fixes #4 

Adds common output/metadata artifacts to the `.gitignore` file.

DCO 1.1 Signed-off-by: Andrew R. Freed afreed@us.ibm.com