### PR TITLE
use sythesize not transcribe

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ voice=en-US_MichaelV3Voice
 ;customization_id=xxxxxxxxx-xxxxx-xxxxx-xxxxxxxxxxx
 
 [Synthesis]
-output_dir=transcriptions
+output_dir=synthesis
 output_file_type=mp3
-input_file = inputfile_to_transcribe.csv
+input_file = inputfile_to_synthesize.csv
 overwrite = True
 ```
 

--- a/config.ini.sample
+++ b/config.ini.sample
@@ -11,11 +11,11 @@ voice=en-US_MichaelV3Voice
 
 [Synthesis]
 # Directory to store output, will be created if needed
-output_dir=transcriptions
+output_dir=synthesis
 # File types from https://cloud.ibm.com/docs/text-to-speech?topic=text-to-speech-audio-formats#formats-supported
 output_file_type=mp3
 # CSV file with two columns: 'id' (used for creating a file with audio), 'text' (the text to synthesize)
-input_file = inputfile_to_transcribe.csv
+input_file = inputfile_to_synthesize.csv
 # True to overwrite existing audio files, False otherwise
 overwrite = True
 
@@ -32,7 +32,7 @@ output_file=tts_pronounce.csv
 [Assistant]
 # Output CSV file with two columns: 'id' (used for creating a file with audio), 'text' (the text to synthesize)
 # This file is suitable for use in [Synthesis] as `input_file`
-extracted_skill_text_file=inputfile_to_transcribe.csv
+extracted_skill_text_file=inputfile_to_synthesize.csv
 
 # Provide either an exported copy of your Watson Assistant skill OR connection details to read the skill online
 # Exported JSON from Watson Assistant

--- a/config.py
+++ b/config.py
@@ -1,10 +1,5 @@
 import configparser
 
-STT_SECTION_KEY="SpeechToText"
-TRANSCRIPTIONS_SECTION_KEY="Transcriptions"
-OUTPUT_SECTION_KEY="ErrorRateOutput"
-TRANSFORMATIONS_SECTION_KEY="Transformations"
-
 class Config:
     config = None
 

--- a/synthesize.py
+++ b/synthesize.py
@@ -11,7 +11,7 @@ class Synthesizer:
     def __init__(self, config):
         self.config = config
         self.TTS = self.createTTS()
-        self.transcription_count = 0
+        self.synthesis_count = 0
 
     def createTTS(self):
         return WatsonObjects(self.config).createTTS()
@@ -53,13 +53,13 @@ class Synthesizer:
                         accept='audio/' + type,
                         customization_id=customization_id     
                     ).get_result().content)
-                self.transcription_count += 1
+                self.synthesis_count += 1
                 print("Wrote {}".format(output_filename))
             except:
-                print(f"Error transcribing for {output_filename} with text '{text}'")
+                print(f"Error synthesizing for {output_filename} with text '{text}'")
 
     def report(self):
-        print("Wrote {} transcriptions".format(self.transcription_count))
+        print("Wrote {} syntheses".format(self.synthesis_count))
 
 def main():
     config_file = "config.ini"


### PR DESCRIPTION
Fixes #3

Fixes copy/paste error from STT project where default variables were versions of 'transcribe' rather than 'synthesize'

DCO 1.1 Signed-off-by: Andrew R. Freed <afreed@us.ibm.com>