### PR TITLE
use first voice in the list for pronounce tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ reference_transcriptions_file=reference_transcriptions.csv
 ```
 
 ## pronounce.py
-Takes an input file with one word/word phrase per line and generates pronunciations.  Global configuration is updated in `config.ini` file.    The output file from this process is suitable for passing as an input file to `synthesize.py`.
+Takes an input file with one word/word phrase per line and generates pronunciations.  Global configuration is updated in `config.ini` file. Note, If `voice` is set to multiple voices, only the first one will be used. The output file from this process is suitable for passing as an input file to `synthesize.py`.
 
 Example input file:
 ```

--- a/pronounce.py
+++ b/pronounce.py
@@ -25,7 +25,8 @@ class Pronouncer:
 
         num_total        = len(data)
         num_pronounced   = 0
-        voice            = self.config.getValue("TextToSpeech", "voice")
+        # use the first voice in the list
+        voice            = self.config.getValue("TextToSpeech", "voice").split(",")[0]
         customization_id = self.config.getValue("TextToSpeech", "customization_id")
         phonetic         = self.config.getValue("Pronunciation", "phonetic")
 


### PR DESCRIPTION
fix for bug found in issue #12 where pronounce didn't work after merging the changes for #11 

DCO 1.1 Signed-off-by: Terrence Nixa [tnixa@us.ibm.com](mailto:tnixa@us.ibm.com)