### PR TITLE
exception logging

### DIFF
--- a/pronounce.py
+++ b/pronounce.py
@@ -50,8 +50,8 @@ class Pronouncer:
                 ssml_out = f"<speak version='1.0'><phoneme alphabet='{phonetic}' ph='{phoneme_sequence}'>{text}</phoneme></speak>"
                 self.pronunciations.append({'id':id, 'text':ssml_out})
                 print(f"  Pronounced \"{text}\" ({num_pronounced} of {num_total})")
-            except:
-                print(f"Error pronouncing \"{text}\" ({num_pronounced} of {num_total})")
+            except Exception as e:
+                print(f"Error pronouncing \"{text}\" ({num_pronounced} of {num_total})", e)
 
     def report(self):
         output_filename = self.config.getValue("Pronunciation", "output_file")

--- a/synthesize.py
+++ b/synthesize.py
@@ -93,9 +93,9 @@ class Synthesizer:
                         ).get_result().content)
                     self.synthesis_count += 1
                     print("Wrote {}".format(output_filename))
-                except:
+                except Exception as e:
                     print(f"Attempt {attempt} failed")
-                    print(f"Error synthesizing for {output_filename} with text '{text}'")
+                    print(f"Error synthesizing for {output_filename} with text '{text}'", e)
                     print("Retrying...")
                     continue
                 break


### PR DESCRIPTION
print exception rather than swallow exception - most useful when connection details/API key are incorrect

Signed-off-by: Andrew R Freed <afreed@us.ibm.com>